### PR TITLE
Support gulp-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,22 @@ You can pass a base for other templates to be included in a template. It default
     .pipe(liquify(locals, { base: "../templates/" }))
 });
 ```
-You can pass file specific locals by attaching it to the vinyl file object in a previous task.
+You can pass file specific locals through the `gulp-data` plugin.
 
 ```js
 var liquify = require('gulp-liquify');
-var through = require('through2');
+var data = require('gulp-data');
 
 gulp.task("liquify", function() {
   var locals = {
     name: "Fred"
   };
   gulp.src('*.liquid')
-    .pipe(through.obj(function(file, enc, cb) {
-      file.locals = {
+    .pipe(data(function(file) {
+      return {
         number: Math.random(),
         path: file.path
       };
-      cb(null, file);
     }))
     .pipe(liquify(locals))
     .pipe(gulp.dest('./dist/'))

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ function gulpLiquify(locals, options) {
     // Clone a fresh copy, so as not to affect others
     var tempLocals = locals ? _.clone(locals) : {};
 
-    // Apply file specific locals
-    if(file.locals) {
-      tempLocals = _.defaults(file.locals, tempLocals);
+    // Apply file specific data
+    if(file.data) {
+      tempLocals = _.defaults(file.data, tempLocals);
     }
 
     liquify(file.contents.toString("utf-8"), tempLocals, settings.base || file.base, settings.prefix)

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.1",
+    "gulp-data": "^1.2.1",
     "mocha": "^2.0.1",
     "should": "^7.0.2"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -54,20 +54,19 @@ describe('gulp-liquify', function() {
         });
     });
     
-    it('includes passed file.locals', function (done) {
-      var through = require("through2");
+    it('includes locals from gulp-data', function (done) {
+      var data = require('gulp-data');
 
       var locals = {
         name: "Fred"
       };
       
       gulp.src(fixtures("passed.liquid"))
-        .pipe(through.obj(function(file, enc, cb) {
-          file.locals = {
-            name: "Derf"
-          };
-          cb(null, file);
-        }))
+        .pipe(data(function(file) {
+	  return {
+	    name: "Derf"
+	  };
+	}))
         .pipe(liquify(locals))
         .on('data', function (data) {
           var content = data.contents.toString();


### PR DESCRIPTION
The [gulp-data](https://github.com/colynb/gulp-data) plugin specifies a common API for incorporating JSON data. This pull request changes `file.locals` to the common `file.data` and adjusts a test case accordingly.
